### PR TITLE
Allow switching of i2c peripheral and free pins 19 and 20.

### DIFF
--- a/inc/microbit/modmicrobit.h
+++ b/inc/microbit/modmicrobit.h
@@ -217,15 +217,19 @@ extern volatile bool compass_updating;
 extern const struct _microbit_compass_obj_t microbit_compass_obj;
 
 void microbit_compass_init(void);
+void microbit_compass_acquire(void);
 
 /****************************************************************/
 // microbit.accelerometer object
 
 extern volatile bool accelerometer_up_to_date;
 extern volatile bool accelerometer_updating;
+extern volatile bool accelerometer_in_use;
 
 extern const mp_obj_type_t microbit_accelerometer_type;
 extern const struct _microbit_accelerometer_obj_t microbit_accelerometer_obj;
+
+bool microbit_accelerometer_acquire(void);
 
 //void microbit_accelerometer_event_handler(const MicroBitEvent *evt);
 
@@ -240,9 +244,14 @@ void microbit_button_tick(void);
 /****************************************************************/
 // microbit.i2c, microbit.uart and microbit.spi objects
 
+extern volatile bool i2c_in_use;
+
 extern const struct _microbit_i2c_obj_t microbit_i2c_obj;
 extern struct _microbit_uart_obj_t microbit_uart_obj;
 extern struct _microbit_spi_obj_t microbit_spi_obj;
+
+bool i2c_matches_accel(void);
+void microbit_i2c_free_current(void);
 
 /****************************************************************/
 // declarations of microbit functions and methods

--- a/source/microbit/main.cpp
+++ b/source/microbit/main.cpp
@@ -39,6 +39,7 @@ void microbit_ticker(void) {
     // Update compass if it is calibrating, but not if it is still
     // updating as compass.idleTick() is not reentrant.
     if (ubit_compass->isCalibrating() && !compass_updating) {
+        microbit_compass_acquire();
         ubit_compass->idleTick();
     }
 

--- a/source/microbit/microbitcompass.cpp
+++ b/source/microbit/microbitcompass.cpp
@@ -39,6 +39,12 @@ typedef struct _microbit_compass_obj_t {
     mp_obj_base_t base;
 } microbit_compass_obj_t;
 
+void microbit_compass_acquire(void) {
+    if (microbit_accelerometer_acquire()) {
+        ubit_compass->configure();
+    }
+}
+
 void microbit_compass_init(void) {
     // load any peristent calibration data if it exists
     uint32_t *persist = (uint32_t*)microbit_compass_calibration_page();
@@ -62,6 +68,7 @@ mp_obj_t microbit_compass_calibrate(mp_obj_t self_in) {
     // can use the display to collect samples for the calibration.
     // It will do the calibration and then return here.
     (void)self_in;
+    microbit_compass_acquire();
     ticker_stop();
     //uBit.systemTicker.attach_us(&uBit, &MicroBit::systemTick, MICROBIT_DEFAULT_TICK_PERIOD * 1000); TODO what to replace with?
     ubit_display.enable();
@@ -114,6 +121,7 @@ static void update(microbit_compass_obj_t *self) {
 
 mp_obj_t microbit_compass_heading(mp_obj_t self_in) {
     microbit_compass_obj_t *self = (microbit_compass_obj_t*)self_in;
+    microbit_compass_acquire();
     // Upon calling heading(), the DAL will automatically calibrate the compass
     // if it's not already calibrated.  Since we need to first enable the display
     // for calibration to work, we must check for non-calibration here and call
@@ -128,24 +136,28 @@ MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_heading_obj, microbit_compass_heading
 
 mp_obj_t microbit_compass_get_x(mp_obj_t self_in) {
     (void)self_in;
+    microbit_compass_acquire();
     return mp_obj_new_int(ubit_compass->getX());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_x_obj, microbit_compass_get_x);
 
 mp_obj_t microbit_compass_get_y(mp_obj_t self_in) {
     (void)self_in;
+    microbit_compass_acquire();
     return mp_obj_new_int(ubit_compass->getY());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_y_obj, microbit_compass_get_y);
 
 mp_obj_t microbit_compass_get_z(mp_obj_t self_in) {
     (void)self_in;
+    microbit_compass_acquire();
     return mp_obj_new_int(ubit_compass->getZ());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_z_obj, microbit_compass_get_z);
 
 mp_obj_t microbit_compass_get_field_strength(mp_obj_t self_in) {
     (void)self_in;
+    microbit_compass_acquire();
     return mp_obj_new_int(ubit_compass->getFieldStrength());
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_field_strength_obj, microbit_compass_get_field_strength);

--- a/source/microbit/microbitpinmode.c
+++ b/source/microbit/microbitpinmode.c
@@ -104,6 +104,6 @@ const microbit_pinmode_t microbit_pinmodes[] = {
     [MODE_MUSIC]         = { MP_QSTR_music, pinmode_error },
     [MODE_AUDIO_PLAY]    = { MP_QSTR_audio, noop },
     [MODE_TOUCH]         = { MP_QSTR_touch, noop },
-    [MODE_I2C]           = { MP_QSTR_i2c, pinmode_error },
+    [MODE_I2C]           = { MP_QSTR_i2c, noop },
     [MODE_SPI]           = { MP_QSTR_spi, pinmode_error }
 };


### PR DESCRIPTION
Using i2c in conjunction with the accelerometer no longer breaks the accelerometer as both keep track of i2c use and reset themselves when necessary.
The pins 19 and 20 can now also be used as normal digital pins as the functions that rely on the accelerometer and the i2c will reset the pins when necessary.